### PR TITLE
feat(web): persist diff state in cookies

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { DiffRequest, DiffResult, RefsResponse, SessionInfo } from "@diffview/shared";
 import { Virtualizer } from "@pierre/diffs/react";
@@ -8,7 +8,7 @@ import Patch from "./components/Patch";
 import DiffTreeSidebar from "./components/DiffTreeSidebar";
 import { fetchData } from "@utils/http";
 import { useDiffModeStore } from "./store/diff-mode.store";
-import { getCookie, useCookieState } from "./hooks/useCookieState";
+import { useCookieState } from "./hooks/useCookieState";
 
 function App() {
   const { current: diffMode } = useDiffModeStore();
@@ -16,11 +16,8 @@ function App() {
   const [refs, setRefs] = useState<RefsResponse | null>(null);
   const [diff, setDiff] = useState<DiffResult | null>(null);
 
-  const baseBranchCookieKey = useMemo(
-    () => (session ? `base-branch:${session.repo.name}` : ""),
-    [session],
-  );
-  const [baseBranch, setBaseBranch] = useCookieState(baseBranchCookieKey, "", {
+  const baseBranchCookieKey = session ? `base-branch:${session.repo.name}` : "";
+  const [baseBranch, setBaseBranch] = useCookieState(baseBranchCookieKey, session?.defaultBaseRef ?? "", {
     enabled: !!baseBranchCookieKey,
   });
 
@@ -43,18 +40,12 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (!session || !baseBranchCookieKey) return;
-    if (getCookie(baseBranchCookieKey) === null) {
-      setBaseBranch(session.defaultBaseRef);
-    }
-  }, [baseBranchCookieKey, session, setBaseBranch]);
-
-  useEffect(() => {
+    if (!session) return;
     const loadDiff = async () => {
       const request: DiffRequest = { mode: diffMode };
       if (diffMode === "branch") {
-        if (!session) return;
-        request.base = baseBranch || session.defaultBaseRef;
+        if (!baseBranch) return;
+        request.base = baseBranch;
         request.head = session.currentBranch;
       }
       const response = await fetchData<DiffResult>("/diff", {
@@ -72,11 +63,7 @@ function App() {
 
   return (
     <div className="flex h-dvh min-h-screen flex-col bg-background text-foreground">
-      <Header
-        branches={repoBranches}
-        baseBranch={baseBranch}
-        onBaseBranchChange={setBaseBranch}
-      />
+      <Header branches={repoBranches} baseBranch={baseBranch} onBaseBranchChange={setBaseBranch} />
       <div className="grid min-h-0 flex-1 grid-cols-[280px_minmax(0,1fr)] overflow-hidden">
         <DiffTreeSidebar
           files={diff?.files ?? []}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -29,28 +29,29 @@ const Header: FC<HeaderProps> = ({ branches, baseBranch, onBaseBranchChange }) =
   return (
     <div className="flex w-full items-center justify-between border px-4 py-3">
       <div className="flex items-center gap-2">
-        <Select
-          onValueChange={(value) => update(value as DiffMode)}
-          value={current}
-        >
-        <SelectTrigger className="w-45">
-          <SelectValue placeholder="Diff mode" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            {items.map((item) => (
-              <SelectItem key={item.value} value={item.value}>
-                {item.label}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
+        <Select onValueChange={(value) => update(value as DiffMode)} value={current}>
+          <SelectTrigger className="w-45">
+            <SelectValue placeholder="Diff mode" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {items.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
         </Select>
 
         {current === "branch" ? (
-          <Select onValueChange={onBaseBranchChange} value={baseBranch}>
+          <Select
+            onValueChange={onBaseBranchChange}
+            value={baseBranch}
+            disabled={branches.length === 0}
+          >
             <SelectTrigger className="w-45">
-              <SelectValue placeholder="Base branch" />
+              <SelectValue placeholder={branches.length === 0 ? "Loading branches…" : "Base branch"} />
             </SelectTrigger>
             <SelectContent>
               <SelectGroup>

--- a/apps/web/src/hooks/useCookieState.ts
+++ b/apps/web/src/hooks/useCookieState.ts
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from "react";
 
 export function getCookie(name: string): string | null {
   if (typeof document === "undefined") return null;
-  const match = document.cookie.split("; ").find((row) => row.startsWith(`${name}=`));
+  const match = document.cookie.split("; ").find((row) => {
+    const [key] = row.split("=");
+    return key === name;
+  });
   return match ? decodeURIComponent(match.split("=").slice(1).join("=")) : null;
 }
 

--- a/apps/web/src/store/diff-mode.store.ts
+++ b/apps/web/src/store/diff-mode.store.ts
@@ -1,4 +1,4 @@
-import type { DiffMode } from "@diffview/shared";
+import { DIFF_MODES, type DiffMode } from "@diffview/shared";
 import { create } from "zustand";
 
 import { getCookie, setCookie } from "src/hooks/useCookieState";
@@ -10,8 +10,14 @@ interface DiffModeStore {
   update: (v: DiffMode) => void;
 }
 
+function isDiffMode(value: string | null): value is DiffMode {
+  return value !== null && DIFF_MODES.includes(value as DiffMode);
+}
+
+const storedDiffMode = getCookie(DIFF_MODE_COOKIE);
+
 export const useDiffModeStore = create<DiffModeStore>()((set) => ({
-  current: (getCookie(DIFF_MODE_COOKIE) as DiffMode | null) ?? "working",
+  current: isDiffMode(storedDiffMode) ? storedDiffMode : "working",
   update: (v) => {
     setCookie(DIFF_MODE_COOKIE, v, 60 * 60 * 24 * 30);
     set(() => ({ current: v }));


### PR DESCRIPTION
Persists the diff mode and base branch selection in cookies.

Highlights:
- diff mode is restored on reload
- base branch is persisted per repo
- base branch picker remains only in branch mode
- implemented with a small dedicated cookie hook
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sargon17/diffview/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose a base branch in the diff viewer to compare against different repository branches.
  * Diff mode and base-branch choices are persisted via cookies so preferences survive sessions.

* **Refactor**
  * Header now accepts props to control branch selection and renders a controlled base-branch selector.
  * Added a cookie-backed state utility and updated diff-mode persistence to use it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->